### PR TITLE
add basic .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+build
+npm-debug.log
+.env
+.DS_Store


### PR DESCRIPTION
It is a best practice to not track the `node_modules` directory, so I'm adding a basic `.gitignore` file so that isn't tracked along with some other common items.